### PR TITLE
Add workflow and fixes for building universal JAR file and Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, main ]
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:
@@ -92,7 +92,7 @@ jobs:
         path: composeApp/build/compose/binaries/main-release/**/*
         retention-days: 30
 
-    - name: Upload Jar artifacts
+    - name: Upload JAR artifacts
       uses: actions/upload-artifact@v4
       with:
         name: desktop-jar

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -100,7 +100,7 @@ compose.desktop {
         }
 
         nativeDistributions {
-            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+            targetFormats(TargetFormat.Dmg, TargetFormat.Exe, TargetFormat.AppImage)
             packageName = "overport"
             packageVersion = appVersion
 


### PR DESCRIPTION
Hi! Created a advanced workflow for building artifacts for universal Jar and Linux deb package. Based on this PR #16 
Looks like it working now:

Link for artifact log: https://github.com/viktor02/ovrport-app/actions/runs/19251525298

<img width="801" height="608" alt="image" src="https://github.com/user-attachments/assets/1fd7f44a-7e3c-4594-9c80-1a415d21ddfe" />
